### PR TITLE
Fix private key formatting and skip duplicate changelog commits

### DIFF
--- a/src/config/constants.js
+++ b/src/config/constants.js
@@ -37,7 +37,5 @@ if (missingVariables.length > 0) {
   process.exit(1);
 }
 
-console.log(`${APP_GITHUB_PRIVATE_KEY}`);
-
 export const API_PATH_SUFFIX = "/api/v1";
 export const CHANGESET_PATH = "changelogs/fragments";

--- a/src/config/constants.js
+++ b/src/config/constants.js
@@ -36,5 +36,7 @@ if (missingVariables.length > 0) {
   process.exit(1);
 }
 
+console.log(`${APP_GITHUB_PRIVATE_KEY}`);
+
 export const API_PATH_SUFFIX = "/api/v1";
 export const CHANGESET_PATH = "changelogs/fragments";

--- a/src/config/constants.js
+++ b/src/config/constants.js
@@ -13,9 +13,10 @@ dotenv.config({ path: envPath });
 export const {
   PORT = 8080,
   APP_GITHUB_IDENTIFIER,
-  APP_GITHUB_PRIVATE_KEY,
   CHANGELOG_PR_BRIDGE_API_KEY,
 } = process.env;
+
+export const APP_GITHUB_PRIVATE_KEY = atob(process.env.APP_GITHUB_PRIVATE_KEY);
 
 const requiredVariables = [
   "APP_GITHUB_IDENTIFIER",

--- a/src/config/constants.js
+++ b/src/config/constants.js
@@ -16,6 +16,8 @@ export const {
   CHANGELOG_PR_BRIDGE_API_KEY,
 } = process.env;
 
+// Decode the GitHub private key from base64. Due to the way AWS Elastic Beanstalk handles environment variables, 
+// we need to store the private key as a base64 encoded string and decode it here.
 export const APP_GITHUB_PRIVATE_KEY = atob(process.env.APP_GITHUB_PRIVATE_KEY);
 
 const requiredVariables = [
@@ -30,8 +32,7 @@ const missingVariables = requiredVariables.filter(
 
 if (missingVariables.length > 0) {
   console.error(
-    `${missingVariables.join(", ")} ${
-      missingVariables.length > 1 ? "are" : "is"
+    `${missingVariables.join(", ")} ${missingVariables.length > 1 ? "are" : "is"
     } required env values`
   );
   process.exit(1);

--- a/src/controllers/file.controllers.js
+++ b/src/controllers/file.controllers.js
@@ -40,7 +40,7 @@ const createOrUpdateFile = async (req, res, next) => {
     const { content, message } = req.body;
     const decodedContent = Buffer.from(content, "base64").toString("utf-8");
     const octokit = await authServices.getOctokitClient(owner, repo);
-    await fileServices.createOrUpdateFileByPath(
+    const { message: fileServiceMsg } = await fileServices.createOrUpdateFileByPath(
       octokit,
       owner,
       repo,
@@ -49,7 +49,7 @@ const createOrUpdateFile = async (req, res, next) => {
       decodedContent,
       message
     );
-    res.status(201).json({ message: "File created/updated successfully" });
+    res.status(201).json({ message: fileServiceMsg || "File created/updated successfully" });
   } catch (error) {
     next(error);
   }

--- a/src/services/file.services.js
+++ b/src/services/file.services.js
@@ -125,6 +125,9 @@ const createOrUpdateFileByPath = async (
       currentContent = Buffer.from(changesetFile.content, 'base64').toString();
     }
 
+    console.log('Current content:', currentContent);
+    console.log('New content:', content);
+
     // Compare the current content with the new content
     if (currentContent === content) {
       console.log('No changes to the file content. Skipping update.');

--- a/src/services/file.services.js
+++ b/src/services/file.services.js
@@ -125,9 +125,6 @@ const createOrUpdateFileByPath = async (
       currentContent = Buffer.from(changesetFile.content, 'base64').toString();
     }
 
-    console.log('Current content:', currentContent);
-    console.log('New content:', content);
-
     // Compare the current content with the new content
     if (currentContent === content) {
       console.log('No changes to the file content. Skipping update.');

--- a/src/services/file.services.js
+++ b/src/services/file.services.js
@@ -116,24 +116,38 @@ const createOrUpdateFileByPath = async (
       branch,
       path
     );
-    // const sha = changesetFile ? changesetFile.sha : undefined;
-    await octokit.rest.repos.createOrUpdateFileContents({
-      owner: owner,
-      repo: repo,
-      branch: branch,
-      path: path,
-      message: message,
-      content: Buffer.from(content).toString("base64"),
-      sha: changesetFile?.sha,
-    });
-    // Log the message determined by the calling function
-    console.log(message);
-    return { message: message };
+
+    let currentContent = '';
+
+    // Check if the file already exists
+    if (changesetFile && changesetFile.content) {
+      // Decode the Base64 encoded content
+      currentContent = Buffer.from(changesetFile.content, 'base64').toString();
+    }
+
+    // Compare the current content with the new content
+    if (currentContent === content) {
+      console.log('No changes to the file content. Skipping update.');
+      return { message: 'No changes to the file content. Skipping update.' };
+    } else {
+      await octokit.rest.repos.createOrUpdateFileContents({
+        owner: owner,
+        repo: repo,
+        branch: branch,
+        path: path,
+        message: message,
+        content: Buffer.from(content).toString("base64"),
+        sha: changesetFile?.sha,
+      });
+      console.log(message);
+      return { message: message };
+    }
   } catch (error) {
     console.error(`Error creating/updating file '${path}':`, error.message);
     throw error;
   }
 };
+
 
 /**
  * Deletes a file from the GitHub repository.


### PR DESCRIPTION
Contains two changes:
1. Uses base64 to pass private key to the bridge on AWS Elastic Beanstalk
2. Skips the change commit if the contents of the changelog are the same